### PR TITLE
Diagnose Xcode build failure

### DIFF
--- a/Sources/LLMChat/Resources/Info.plist
+++ b/Sources/LLMChat/Resources/Info.plist
@@ -33,8 +33,6 @@
                 <dict>
                     <key>UISceneConfigurationName</key>
                     <string>Default Configuration</string>
-                    <key>UISceneDelegateClassName</key>
-                    <string>$(PRODUCT_MODULE_NAME).SceneDelegate</string>
                 </dict>
             </array>
         </dict>

--- a/Sources/ShareExtension/Info.plist
+++ b/Sources/ShareExtension/Info.plist
@@ -36,12 +36,10 @@
                 <integer>5</integer>
             </dict>
         </dict>
-        <key>NSExtensionMainStoryboard</key>
-        <string>MainInterface</string>
         <key>NSExtensionPointIdentifier</key>
         <string>com.apple.share-services</string>
         <key>NSExtensionPrincipalClass</key>
-        <string>ShareViewController</string>
+        <string>$(PRODUCT_MODULE_NAME).ShareViewController</string>
     </dict>
     <key>UIRequiredDeviceCapabilities</key>
     <array>


### PR DESCRIPTION
Fix Xcode build errors by updating Info.plist configurations for the main app and share extension.

---
<a href="https://cursor.com/background-agent?bcId=bc-63b7433a-b36a-439c-83c1-b3186e9c80c6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-63b7433a-b36a-439c-83c1-b3186e9c80c6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

